### PR TITLE
Add SUBGENERATOR_CLASS

### DIFF
--- a/entities.py
+++ b/entities.py
@@ -455,7 +455,7 @@ class EntityGenerator(generators.Generator):
             tags = list(map(itemgetter(1), tag_cloud))
             if tags:
                 max_count = max(tags)
-            steps = self.settings.get('TAG_CLOUD_STEPS')
+            steps = self.settings.get('TAG_CLOUD_STEPS', 1)
 
             # calculate word sizes
             self.tag_cloud = [


### PR DESCRIPTION
This adds a new configuration key to `ENTITY_TYPES` entries, `SUBGENERATOR_CLASS`. The value may be any callable matching the `entities.EntityGenerator.EntitySubGenerator` interface. Otherwise the value should be an import path to such a callable which will be imported dynamically.

This change allows fully customizable entity generators by specifying `EntitySubGenerator` sub-classes that override some behaviors.
